### PR TITLE
Corrección gramatical en notebook

### DIFF
--- a/zzz-nb003-basic-graph-ESP.ipynb
+++ b/zzz-nb003-basic-graph-ESP.ipynb
@@ -565,10 +565,10 @@
    "metadata": {},
    "source": [
     "## Cómo ejecutar el código desde Visual Studio Code  \n",
-    "* En Visual Studio Code, abre el archivo **`003-basic-langgraph.py`**.  \n",
+    "* En Visual Studio Code, abre el archivo **`003-basic-graph.py`**.  \n",
     "* En la terminal, asegúrate de estar en el directorio del archivo y ejecuta:  \n",
     "    * ```bash\n",
-    "      python 003-basic-langgraph.py\n",
+    "      python 003-basic-graph.py\n",
     "      ```"
    ]
   },


### PR DESCRIPTION
El comando hace referencia al archivo "003-basic-langgraph.py" el cual no existe, el nombre correcto es "003-basic-graph.py"